### PR TITLE
fix: export LogEntry and include timestamp in websocket message

### DIFF
--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -1,4 +1,5 @@
-interface LogEntry {
+// Exported so other modules can type their log handling correctly
+export interface LogEntry {
   timestamp: string;
   level: 'info' | 'error' | 'warn' | 'debug' | 'request';
   message: string;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -285,4 +285,6 @@ export type WebSocketMessage = {
   paused?: boolean;
   asset?: string;
   accountBalance?: AccountBalance;
+  // Optional timestamp used by clients to bust caches
+  timestamp?: number;
 };


### PR DESCRIPTION
## Summary
- export `LogEntry` so modules can type log entries
- extend `WebSocketMessage` with optional `timestamp`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: multiple TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68ab5ab525d0832b82e6a4a80c4e203b